### PR TITLE
feat: accept an optional tag type in MessageCall

### DIFF
--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -28,21 +28,21 @@ macro_rules! impl_display_and_from_str_for_type {
     };
 }
 
-#[derive(PartialEq, Debug, Copy, Clone, Default, DeserializeFromStr, SerializeDisplay)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Default, DeserializeFromStr, SerializeDisplay)]
 pub struct LegacyType;
 impl LegacyType {
     const TYPE: &'static str = "0x00";
 }
 impl_display_and_from_str_for_type!(LegacyType);
 
-#[derive(PartialEq, Debug, Copy, Clone, Default, DeserializeFromStr, SerializeDisplay)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Default, DeserializeFromStr, SerializeDisplay)]
 pub struct EIP2930Type;
 impl EIP2930Type {
     const TYPE: &'static str = "0x01";
 }
 impl_display_and_from_str_for_type!(EIP2930Type);
 
-#[derive(PartialEq, Debug, Copy, Clone, Default, DeserializeFromStr, SerializeDisplay)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Default, DeserializeFromStr, SerializeDisplay)]
 pub struct EIP1559Type;
 impl EIP1559Type {
     const TYPE: &'static str = "0x02";
@@ -57,7 +57,7 @@ pub struct AccessListEntry {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum MessageCall {
     #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
ethers-rs adds a tag type to their requests if not using legacy feature.
```rust
pub enum TypedTransaction {
    // 0x00
    #[serde(rename = "0x00")]
    Legacy(TransactionRequest),
    // 0x01
    #[serde(rename = "0x01")]
    Eip2930(Eip2930TransactionRequest),
    // 0x02
    #[serde(rename = "0x02")]
    Eip1559(Eip1559TransactionRequest),
}
```

This is also specified in the openethereum docs
https://openethereum.github.io/JSONRPC.html#transactions

This diff adds support to optionally serialize/deserialize this type.
