### PR TITLE
Enable derive_default_enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![feature(
+    derive_default_enum
+)]
 #![doc = include_str!("../README.md")]
 
 mod debug;


### PR DESCRIPTION
Fixes  error:

```
deriving `Default` on enums is experimental
```

<img width="931" alt="image" src="https://user-images.githubusercontent.com/787344/189184667-56d45c8c-ec30-4078-8775-8ed3cb547df4.png">
